### PR TITLE
Change to add python 3.9 & CCS 12 compatibility

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -2,7 +2,7 @@
 
 echo "Running pre-commit hook"
 added_files=$(git diff --cached --name-only | grep "\.py" | tr '\n' ' ')
-if [ -n "${added_files// }" ]; then
+if [ -n "${added_files}" ]; then
     echo "running flake8 on ${added_files}"
     flake8 --exclude=__init__.py --ignore=E128 $added_files
     if [ $? -ne 0 ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
 tox
 jinja2
+pytest
+pytest-html

--- a/tiflash/utils/result.py
+++ b/tiflash/utils/result.py
@@ -20,7 +20,7 @@ MAX_CLIENTS = 1
 if pyversion[0] == 2:
     SOCK_TIMEOUT = None   # timeouts don't seem to work for py2
 else:
-    SOCK_TIMEOUT = 60   # timeout to wait for result
+    SOCK_TIMEOUT = 120   # timeout to wait for result #increased from 60 for CCS12 compatibility
 
 
 class ResultServerError(Exception):
@@ -83,11 +83,11 @@ class ResultServer(object):
                 If 'None' will block/wait forever. If '0' will not block.
 
         """
-        if self.server_thread.isAlive() is True:
+        if self.server_thread.is_alive() is True:
             self.server_thread.join(timeout=timeout)
 
             # Thread should only be alive if timeout was exceeded
-            if self.server_thread.isAlive is True:
+            if self.server_thread.is_alive is True:
                 return None
 
         if type(self.result) == str:

--- a/tiflash/version.py
+++ b/tiflash/version.py
@@ -1,3 +1,3 @@
-version = (1, 2, 9)
+version = (1, 3, 0)
 version_string = ".".join(map(str,version))
-release_date = "2019.08.23"
+release_date = "2022.07.05"


### PR DESCRIPTION
Relate to Bug #90
Just added two minor changes:
* isAlive to is_alive for 3.9 compatibility
* timeout increase from 60 s to 120s for CCS12

CCS12 has some warning messages being printed but that is from CCS12 & has nothing to do with tiflash.

Ran all pytest for python 2.7, 3.7 & 3.9 with CCS 10.4 & CCS 12.0. Reports attached as pdf.

[junit-python2.7.xml.pdf](https://github.com/webbcam/tiflash/files/9066108/junit-python2.7.xml.pdf)
[junit-python3.7.xml.pdf](https://github.com/webbcam/tiflash/files/9066109/junit-python3.7.xml.pdf)
[junit-python3.9.xml.pdf](https://github.com/webbcam/tiflash/files/9066110/junit-python3.9.xml.pdf)
